### PR TITLE
feat: improve cell value display and modal save behavior

### DIFF
--- a/src/components/CommitmentCellModal.tsx
+++ b/src/components/CommitmentCellModal.tsx
@@ -128,25 +128,37 @@ export default function CommitmentCellModal({
     if (commitment.commitmentType === 'measurement') {
       if (commitment.ratingRange) {
         // Rating type
-        const rating = parseFloat(ratingValue.trim());
-        if (isNaN(rating)) {
-          Alert.alert('Error', 'Please enter a valid rating value.');
-          return;
+        const ratingInput = ratingValue.trim();
+        if (ratingInput === '') {
+          // Allow empty values - will show "-" in display
+          value = undefined;
+        } else {
+          const rating = parseFloat(ratingInput);
+          if (isNaN(rating)) {
+            Alert.alert('Error', 'Please enter a valid rating value.');
+            return;
+          }
+          if (rating < commitment.ratingRange.min || rating > commitment.ratingRange.max) {
+            Alert.alert('Error', `Rating must be between ${commitment.ratingRange.min} and ${commitment.ratingRange.max}.`);
+            return;
+          }
+          value = rating;
         }
-        if (rating < commitment.ratingRange.min || rating > commitment.ratingRange.max) {
-          Alert.alert('Error', `Rating must be between ${commitment.ratingRange.min} and ${commitment.ratingRange.max}.`);
-          return;
-        }
-        value = rating;
         console.log('💾 [Modal] Rating value prepared:', value);
       } else {
         // Measure type
-        const measure = parseFloat(measureValue.trim());
-        if (isNaN(measure)) {
-          Alert.alert('Error', 'Please enter a valid measurement value.');
-          return;
+        const measureInput = measureValue.trim();
+        if (measureInput === '') {
+          // Allow empty values - will show "-" in display
+          value = undefined;
+        } else {
+          const measure = parseFloat(measureInput);
+          if (isNaN(measure)) {
+            Alert.alert('Error', 'Please enter a valid measurement value.');
+            return;
+          }
+          value = measure;
         }
-        value = measure;
         console.log('💾 [Modal] Measure value prepared:', value, 'from input:', measureValue);
       }
     } else if (commitment.commitmentType === 'checkbox' && commitment.requirements) {

--- a/src/utils/valueFormatUtils.ts
+++ b/src/utils/valueFormatUtils.ts
@@ -154,14 +154,19 @@ export function getCellDisplayText(
     return '';
   }
 
+  // Special case: skipped cells should show no content (empty)
+  if (status === 'skipped') {
+    return '';
+  }
+
   // Check if we should display anything at all
   if (!shouldDisplayValue(status, value)) {
     return '';
   }
 
-  // If there's a status but no value, show 0
+  // If there's a status but no value, show -
   if ((value === null || value === undefined) && status && status !== 'none') {
-    return '0';
+    return '-';
   }
 
   // Format and return the value


### PR DESCRIPTION
## Summary
- Show '-' instead of '0' for cells with status but no recorded value
- Skipped cells display empty content (no text/icons) in value mode  
- Modal allows saving measurement commitments without value input
- Comprehensive handling of edge cases for better UX

## Changes Made
### Value Display Logic (`valueFormatUtils.ts`)
- Modified `getCellDisplayText` to return `-` instead of `0` for missing values
- Added special handling for skipped cells to show empty content
- Maintained backward compatibility for icon display mode

### Modal Save Behavior (`CommitmentCellModal.tsx`)
- Updated rating and measurement input validation to allow empty values
- Empty inputs are saved as `undefined` and display as `-` in the grid
- Removed blocking validation errors for missing values

## Test Plan
- [x] Verified all test scenarios pass (8/8 tests)
- [x] Completed with value: Shows the value
- [x] Completed without value: Shows "-"
- [x] Skipped with/without value: Shows empty (colored square only)
- [x] Failed with value: Shows the value
- [x] Failed without value: Shows "-"
- [x] Modal can save without requiring value input

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates cell value display to show '-' for missing values and hide skipped cells; modal now allows saving measurement/rating inputs as empty (undefined).
> 
> - **Value Display (`src/utils/valueFormatUtils.ts`)**:
>   - Skipped cells return empty display in value mode.
>   - Cells with a status but no value show `-` (instead of `0`).
> - **Modal Behavior (`src/components/CommitmentCellModal.tsx`)**:
>   - Rating/measurement inputs accept empty strings; empty inputs saved as `undefined`.
>   - Save preserves user-entered value for any status; clears record when status is `none` and value is `undefined`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98fa0a041a53da395977e507ea038de008b07d9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->